### PR TITLE
[WO-765] Send IDLE DONE via client for timeout detection

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browserbox",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "homepage": "https://github.com/whiteout-io/browserbox",
   "description": "IMAP client for browsers.",
   "author": "Andris Reinman <andris@kreata.ee>",

--- a/src/browserbox.js
+++ b/src/browserbox.js
@@ -342,8 +342,7 @@
             }.bind(this));
             this._idleTimeout = setTimeout(function() {
                 axe.debug(DEBUG_TAG, 'sending idle DONE');
-                // [0x44, 0x4f, 0x4e, 0x45, 0x0d, 0x0a] is ASCII for "DONE\r\n"
-                this.client.socket.send(new Uint8Array([0x44, 0x4f, 0x4e, 0x45, 0x0d, 0x0a]).buffer);
+                this.client.send('DONE\r\n');
                 this._enteredIdle = false;
             }.bind(this), this.TIMEOUT_IDLE);
         }
@@ -362,7 +361,7 @@
         clearTimeout(this._idleTimeout);
         if (this._enteredIdle === 'IDLE') {
             axe.debug(DEBUG_TAG, 'sending idle DONE');
-            this.client.socket.send(new Uint8Array([0x44, 0x4f, 0x4e, 0x45, 0x0d, 0x0a]).buffer);
+            this.client.send('DONE\r\n');
         }
         this._enteredIdle = false;
 


### PR DESCRIPTION
Sending directly through the socket bypasses the timeout detection, hence makes the timeouts only work if there is a command on the socket. This fixes the behavior in the sense that timeouts in IDLE are now being detected and can be recovered from.