### PR TITLE
[WO-782] Log full traffic

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,11 +19,10 @@
   "main": "src/browserbox",
   "dependencies": {
     "wo-utf7": "~2.0.2",
-    "wo-imap-handler": "~0.1.11",
+    "wo-imap-handler": "git://github.com/whiteout-io/imap-handler.git#5397ccde",
     "mimefuncs": "~0.3.4",
     "axe-logger": "~0.0.2",
-    "tcp-socket": "~0.5.0",
-    "es6-promise": "^2.0.1"
+    "tcp-socket": "~0.5.0"
   },
   "devDependencies": {
     "chai": "~1.8.1",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "main": "src/browserbox",
   "dependencies": {
     "wo-utf7": "~2.0.2",
-    "wo-imap-handler": "git://github.com/whiteout-io/imap-handler.git#5397ccde",
+    "wo-imap-handler": "~0.1.14",
     "mimefuncs": "~0.3.4",
     "axe-logger": "~0.0.2",
     "tcp-socket": "~0.5.0"

--- a/test/unit/browserbox-test.js
+++ b/test/unit/browserbox-test.js
@@ -366,7 +366,8 @@
                         value: 'u1'
                     }, {
                         type: 'STRING',
-                        value: 'p1'
+                        value: 'p1',
+                        sensitive: true
                     }]
                 });
 
@@ -390,7 +391,8 @@
                         value: 'XOAUTH2'
                     }, {
                         type: 'ATOM',
-                        value: 'dXNlcj11MQFhdXRoPUJlYXJlciBhYmMBAQ=='
+                        value: 'dXNlcj11MQFhdXRoPUJlYXJlciBhYmMBAQ==',
+                        sensitive: true
                     }]
                 });
 


### PR DESCRIPTION
All traffic is logged excluding long strings, literals and sensitive information (passwords and oauth2 tokens).

Additionally added connection ID to log strings, so if multiple connections are currently open the ID identifies traffic for a particular connection.

**Examples**

1. Password is hidden when logging authentication info (`[1]` identificates the connection)

```
[2015-02-17T09:47:15.254Z][browserbox IMAP] [1] C: W1 login "testuser" "(* value hidden *)"
[2015-02-17T09:47:15.257Z][browserbox IMAP] [1] S: W1 OK User logged in
```

2. Literals are hidden when logging responses

```
[2015-02-17T09:47:15.971Z][browserbox IMAP] [2] C: W2 FETCH 1:* (BODY.PEEK[])
[2015-02-17T09:47:15.972Z][browserbox IMAP] [2] S: * 1 FETCH (BODY[] "(* 228B literal *)")
[2015-02-17T09:47:15.973Z][browserbox IMAP] [2] S: W2 OK FETCH Completed
```

## NB!

Replace `wo-imap-handler` version identifier in [package.json](https://github.com/whiteout-io/browserbox/blob/dev/wo-782/package.json#L22) before merging