### PR TITLE
[WO-904] Merge FETCH responses based on sequence number

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - "0.11"
+  - 0.12
 before_install:
   - npm install -g grunt-cli
 notifications:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browserbox",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "homepage": "https://github.com/whiteout-io/browserbox",
   "description": "IMAP client for browsers.",
   "author": "Andris Reinman <andris@kreata.ee>",

--- a/src/browserbox.js
+++ b/src/browserbox.js
@@ -1478,20 +1478,27 @@
      * @return {Object} Message object
      */
     BrowserBox.prototype._parseFETCH = function(response) {
-        var list;
-
         if (!response || !response.payload || !response.payload.FETCH || !response.payload.FETCH.length) {
             return [];
         }
 
-        list = [].concat(response.payload.FETCH || []).map(function(item) {
-            var
-            // ensure the first value is an array
-                params = [].concat([].concat(item.attributes || [])[0] || []),
-                message = {
+        var list = [];
+        var messages = {};
+
+        [].concat(response.payload.FETCH || []).forEach(function(item) {
+            var params = [].concat([].concat(item.attributes || [])[0] || []); // ensure the first value is an array
+            var message;
+            var i, len, key;
+
+            if (messages[item.nr]) {
+                // same sequence number is already used, so merge values instead of creating a new message object
+                message = messages[item.nr];
+            } else {
+                messages[item.nr] = message = {
                     '#': item.nr
-                },
-                i, len, key;
+                };
+                list.push(message);
+            }
 
             for (i = 0, len = params.length; i < len; i++) {
                 if (i % 2 === 0) {
@@ -1502,8 +1509,6 @@
                 }
                 message[key] = this._parseFetchValue(key, params[i]);
             }
-
-            return message;
         }.bind(this));
 
         return list;

--- a/test/unit/browserbox-test.js
+++ b/test/unit/browserbox-test.js
@@ -1484,6 +1484,54 @@
 
                 br._parseFetchValue.restore();
             });
+
+            it('should merge multiple responses based on sequence number', function() {
+                expect(br._parseFETCH({
+                    payload: {
+                        FETCH: [{
+                            nr: 123,
+                            attributes: [
+                                [{
+                                    type: 'ATOM',
+                                    value: 'UID'
+                                }, {
+                                    type: 'ATOM',
+                                    value: 789
+                                }]
+                            ]
+                        }, {
+                            nr: 124,
+                            attributes: [
+                                [{
+                                    type: 'ATOM',
+                                    value: 'UID'
+                                }, {
+                                    type: 'ATOM',
+                                    value: 790
+                                }]
+                            ]
+                        }, {
+                            nr: 123,
+                            attributes: [
+                                [{
+                                    type: 'ATOM',
+                                    value: 'MODSEQ'
+                                }, {
+                                    type: 'ATOM',
+                                    value: '127'
+                                }]
+                            ]
+                        }]
+                    }
+                })).to.deep.equal([{
+                    '#': 123,
+                    'uid': 789,
+                    'modseq': '127'
+                }, {
+                    '#': 124,
+                    'uid': 790
+                }]);
+            });
         });
 
         describe('#_parseENVELOPE', function() {


### PR DESCRIPTION
An IMAP server might send several responses for the same message.

Eg. instead of this:

    * 123 FETCH (UID 123 MODSEQ 456)

The response might as well be this:

    * 123 FETCH (UID 123)
    * 123 FETCH (MODSEQ 456)

This update makes sure that FETCH responses are merged by the sequence number before returning. Previous behavior for listMessages was to return a separate row for every response

```
[
    {
        '#': 123,
        uid: 123
    },
    {
        '#': 123,
        modseq: 456
    }
]
```

Updated behavior merges these values into one message object as expected

```
[
    {
        '#': 123,
        uid: 123,
        modseq: 456
    }
]
```