### PR TITLE
[WO-03-028] Use addressparser for handling ENVELOPE addresses

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -62,6 +62,7 @@ module.exports = function(grunt) {
                     'wo-utf7/src/utf7.js',
                     'wo-imap-handler/src/*.js',
                     'mimefuncs/src/mimefuncs.js',
+                    'wo-addressparser/src/addressparser.js',
                     'axe-logger/axe.js',
                     'es6-promise/dist/es6-promise.js'
                 ],

--- a/package.json
+++ b/package.json
@@ -18,11 +18,12 @@
   },
   "main": "src/browserbox",
   "dependencies": {
-    "wo-utf7": "~2.0.2",
-    "wo-imap-handler": "~0.1.14",
-    "mimefuncs": "~0.3.4",
     "axe-logger": "~0.0.2",
-    "tcp-socket": "~0.5.0"
+    "mimefuncs": "~0.3.4",
+    "tcp-socket": "~0.5.0",
+    "wo-addressparser": "^0.1.3",
+    "wo-imap-handler": "~0.1.14",
+    "wo-utf7": "~2.0.2"
   },
   "devDependencies": {
     "chai": "~1.8.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browserbox",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "homepage": "https://github.com/whiteout-io/browserbox",
   "description": "IMAP client for browsers.",
   "author": "Andris Reinman <andris@kreata.ee>",

--- a/test/unit/fixtures/envelope.js
+++ b/test/unit/fixtures/envelope.js
@@ -71,6 +71,24 @@ define(function() {
                     }, {
                         value: 'host'
                     }
+                ],
+                [{
+                        value: ''
+                    },
+                    null, {
+                        value: '"evil@attacker.com"'
+                    }, {
+                        value: 'victim.com'
+                    }
+                ],
+                [{
+                        value: 'Last, First'
+                    },
+                    null, {
+                        value: 'first.last'
+                    }, {
+                        value: 'example.com'
+                    }
                 ]
             ],
             [
@@ -161,6 +179,12 @@ define(function() {
             }, {
                 name: 'õäöü 2',
                 address: 'reply.to.2@host'
+            }, {
+                name: '@victim.com',
+                address: 'evil@attacker.com'
+            }, {
+                name: 'Last, First',
+                address: 'first.last@example.com'
             }],
             to: [{
                 name: 'õäöü 1',


### PR DESCRIPTION
Quick fix for removing differences between the reading and replying views, where in reader mode you see one address but in reply view you see another, is to parse all addresses the same way.

So far the reader view addresses are parsed by the IMAP server, all other addresses are handled by addressparser module. This commit changes ENVELOPE handling in a way that the pre-parsed addresses are not used directly, instead these are parsed with addressparser.