### PR TITLE
Explicitly treat Gmail msg/thread id's as numbers for search

### DIFF
--- a/src/browserbox.js
+++ b/src/browserbox.js
@@ -1959,6 +1959,17 @@
                                 value: param
                             };
                             break;
+                        // The Gmail extension values of X-GM-THRID and
+                        // X-GM-MSGID are defined to be unsigned 64-bit integers
+                        // and they must not be quoted strings or the server
+                        // will report a parse error.
+                        case 'x-gm-thrid':
+                        case 'x-gm-msgid':
+                            param = {
+                                type: "number",
+                                value: param
+                            };
+                            break;
                         default:
                             param = escapeParam(param);
                     }

--- a/test/unit/browserbox-test.js
+++ b/test/unit/browserbox-test.js
@@ -1712,7 +1712,9 @@
                     },
                     sentbefore: new Date(2011, 1, 3, 12, 0, 0),
                     since: new Date(2011, 11, 23, 12, 0, 0),
-                    uid: '1:*'
+                    uid: '1:*',
+                    'X-GM-MSGID': '1499257647490662970',
+                    'X-GM-THRID': '1499257647490662971'
                 }, {})).to.deep.equal({
                     command: 'SEARCH',
                     attributes: [{
@@ -1760,6 +1762,18 @@
                     }, {
                         'type': 'sequence',
                         'value': '1:*'
+                    }, {
+                        'type': 'atom',
+                        'value': 'X-GM-MSGID'
+                    }, {
+                        'type': 'number',
+                        'value': '1499257647490662970'
+                    }, {
+                        'type': 'atom',
+                        'value': 'X-GM-THRID'
+                    }, {
+                        'type': 'number',
+                        'value': '1499257647490662971'
                     }]
                 });
             });


### PR DESCRIPTION
They are unsigned 64-bit integers but JS Numbers can't handle that, so callers
need to be able to pass strings and not have search quote them.

Fixes #58.