### PR TITLE
expungeFolder

### DIFF
--- a/src/browserbox.js
+++ b/src/browserbox.js
@@ -1127,10 +1127,6 @@
             });
         }
     
-        if (err) {
-            return callback(err);
-        }
-    
         this.exec('EXPUNGE', function(err, response, next) {
             if (err) {
                 callback(err);

--- a/src/browserbox.js
+++ b/src/browserbox.js
@@ -1107,6 +1107,41 @@
 
         return promise;
     };
+    
+    /**
+     * Messages with \Deleted flag set are deleted
+     *
+     * EXPUNGE details:
+     *   http://tools.ietf.org/html/rfc3501#section-6.4.3
+     *
+     * Callback returns an error if the operation failed
+     *
+     * @param {Function} callback Callback function
+     */
+    BrowserBox.prototype.expungeFolder = function(callback) {
+        var promise;
+    
+        if (!callback) {
+            promise = new Promise(function(resolve, reject) {
+                callback = callbackPromise(resolve, reject);
+            });
+        }
+    
+        if (err) {
+            return callback(err);
+        }
+    
+        this.exec('EXPUNGE', function(err, response, next) {
+            if (err) {
+                callback(err);
+            } else {
+                callback(null, true);
+            }
+            next();
+        }.bind(this));
+    
+        return promise;
+    };
 
     /**
      * Copies a range of messages from the active mailbox to the destination mailbox.


### PR DESCRIPTION
When in WhiteoutMail or just using the browserbox api, deleting a large amount of emails can take a large amount of time. This is because each message is being expunged separately. A better solution may be to flag the messages and then run an expunge function such as this once rather than once per message.