### PR TITLE
Added property specialUseFlag to detect SPECIAL-USE mailboxes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: node_js
+sudo: false
 node_js:
   - 0.12
 before_install:

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ IMAP client for browsers
 
 ## StringEncoding API
 
-This module requires `TextEncoder` and `TextDecoder` to exist as part of the StringEncoding API (see: [MDN](https://developer.mozilla.org/en-US/docs/WebAPI/Encoding_API) [whatwg.org](http://encoding.spec.whatwg.org/#api)). Firefox 19+ is basically the only browser that supports this at the time of writing, while [Chromium in canary, not stable](https://code.google.com/p/chromium/issues/detail?id=243354). Luckily, [there is a polyfill](https://github.com/whiteout-io/stringencoding)!
+This module requires `TextEncoder` and `TextDecoder` to exist as part of the StringEncoding API (see: [MDN](https://developer.mozilla.org/en-US/docs/WebAPI/Encoding_API) [whatwg.org](http://encoding.spec.whatwg.org/#api)). This is supported by Firefox, Chrome and Opera. For other browser environments [there is a polyfill](https://github.com/whiteout-io/stringencoding).
 
 ## TCPSocket API
 
@@ -156,6 +156,7 @@ Mailbox object is with the following structure
   * **listed** (boolean) mailbox was found in the LIST response
   * **subscribed** (boolean) mailbox was found in the LSUB response
   * **specialUse** (string) mailbox was identified as a special use mailbox ('\Trash', '\Sent', '\Junk' etc. see [RFC6154](http://tools.ietf.org/html/rfc6154#section-2))
+  * **specialUseFlag** (string) the same as `specialUse` but without using folder name based heuristics
   * **flags** (array) a list of flags
   * **children** (array) a list of child mailboxes
 
@@ -196,6 +197,7 @@ client.listMailboxes(function(err, mailboxes){
           "flags": ["\\HasNoChildren","\\All"],
           "listed": true,
           "specialUse": "\\All",
+          "specialUseFlag": "\\All",
           "subscribed": true
         }
       ]

--- a/package.json
+++ b/package.json
@@ -26,22 +26,22 @@
     "wo-utf7": "~2.0.2"
   },
   "devDependencies": {
-    "chai": "~1.8.1",
+    "chai": "~3.2.0",
     "grunt": "~0.4.1",
-    "grunt-mocha-phantomjs": "~0.4.0",
-    "grunt-contrib-connect": "~0.6.0",
-    "grunt-contrib-jshint": "~0.8.0",
-    "grunt-contrib-copy": "^0.5.0",
-    "grunt-contrib-clean": "^0.5.0",
+    "grunt-mocha-phantomjs": "~1.0.0",
+    "grunt-contrib-connect": "~0.11.0",
+    "grunt-contrib-jshint": "~0.11.2",
+    "grunt-contrib-copy": "^0.8.0",
+    "grunt-contrib-clean": "^0.6.0",
     "grunt-contrib-watch": "^0.6.1",
-    "mocha": "~1.16.2",
+    "mocha": "~2.2.5",
     "phantomjs": "~1.9.7-1",
     "requirejs": "~2.1.10",
     "sinon": "^1.11.0",
     "hoodiecrow": "^1.1.21",
     "node-forge": "~0.6.11",
     "wo-stringencoding": "~0.1.1",
-    "grunt-mocha-test": "^0.10.2",
+    "grunt-mocha-test": "^0.12.7",
     "es6-promise": "^2.0.1"
   }
 }

--- a/src/browserbox.js
+++ b/src/browserbox.js
@@ -2173,6 +2173,7 @@
                 type = SPECIAL_USE_FLAGS[i];
                 if ((mailbox.flags || []).indexOf(type) >= 0) {
                     mailbox.specialUse = type;
+                    mailbox.specialUseFlag = type;
                     return type;
                 }
             }

--- a/src/browserbox.js
+++ b/src/browserbox.js
@@ -2189,7 +2189,6 @@
         for (i = 0; i < SPECIAL_USE_BOX_FLAGS.length; i++) {
             type = SPECIAL_USE_BOX_FLAGS[i];
             if (SPECIAL_USE_BOXES[type].indexOf(name) >= 0) {
-                mailbox.flags = [].concat(mailbox.flags || []).concat(type);
                 mailbox.specialUse = type;
                 return type;
             }


### PR DESCRIPTION
No idea why the mocha tests don't run. Upgraded all dependencies and still tests don't run :unamused: 

This pull request addresses #67 by adding a new property `specialUseFlag` to mailbox objects which includes the SPECIAL-USE flag if set. Regular `specialUse` property fallbacks to name based heuristics which may backfire if there are several folders that have a matching name (Eg. "Sent", "Sent mail" etc.)