### PR TITLE
Separate connect and login

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,10 +63,6 @@ Where
   * **host** is to hostname to connect to
   * **port** (optional) is the port to connect to (defaults to 143)
   * **options** (optional) is the options object
-    * **auth** is the authentication information object
-      * **user** is the username of the user (also applies to Oauth2)
-      * **pass** is the password of the user
-      * **xoauth2** is the OAuth2 access token to be used instead of password
     * **id** (optional) is the identification object for [RFC2971](http://tools.ietf.org/html/rfc2971#section-3.3) (ex. `{name: 'myclient', version: '1'}`)
     * **useSecureTransport** (optional) enables TLS
     * **ca** (optional) (only in conjunction with the [TCPSocket shim](https://github.com/whiteout-io/tcp-socket)) if you use TLS with forge, pin a PEM-encoded certificate as a string. Please refer to the [tcp-socket documentation](https://github.com/whiteout-io/tcp-socket) for more information!
@@ -82,26 +78,49 @@ Example
 
 ```javascript
 var client = new BrowserBox('localhost', 143, {
-    auth: {
-        user: 'testuser',
-        pass: 'testpass'
-    },
     id: {
         name: 'My Client',
         version: '0.1'
     }
 });
+
+client.connect();
+var auth = { user: 'testuser',   pass: 'testpass' }
+client.login(auth, function(err) {
+      if (err)
+    });
 ```
 
 **Use of web workers with compression**: If you use compression, we can spin up a Web Worker to handle the TLS-related computation off the main thread. To do this, you need to **browserify** `browserbox-compressor-worker.js`, specify the path via `options.compressionWorkerPath`
 
 ## Initiate connection
 
-BrowserBox object by default does not initiate the connection, you need to call `client.connect()` to establish it
+BrowserBox object by default does not initiate the connection, you need to call `client.connect()` to establish it.
 
+```javascript
     client.connect();
+```
 
 This function does not take any arguments and does not return anything. See the events section to handle connection issues.
+
+## Login
+
+Once a connection is established you will need to login.
+
+* **auth** is the authentication information object
+      * **user** is the username of the user (also applies to Oauth2)
+      * **pass** is the password of the user
+      * **xoauth2** is the OAuth2 access token to be used instead of password
+```javascript
+    client.login(auth, function(err) {
+      if (err) {
+        console.log('Error logging in: ' + err);
+      }
+      else {
+        console.log('authentication successful')
+      }
+    });
+```
 
 ## Events
 

--- a/src/browserbox.js
+++ b/src/browserbox.js
@@ -196,8 +196,8 @@
     };
 
     /**
-     * Connection to the server is established. Method performs initial
-     * tasks like updating capabilities and authenticating the user
+     * Connection to the server is established. Update the capabilities, upgrade
+     * the connection if necessary, and identify the server.
      *
      * @event
      */
@@ -218,22 +218,6 @@
                     // capabilities updated, upgraded our connection,
                     // an identified the server.
                     this._changeState(this.STATE_NOT_AUTHENTICATED);
-
-                    // ignore errors for exchanging ID values
-                    this.login(this.options.auth, function(err) {
-                        if (err) {
-                            // emit an error
-                            this.onerror(err);
-                            this.close();
-                            return;
-                        }
-                        // can't setup compression before authnetication
-                        this.compressConnection(function() {
-                            // ignore errors for setting up compression
-                            // emit
-                            this.onauth();
-                        }.bind(this));
-                    }.bind(this));
                 }.bind(this));
             }.bind(this));
         }.bind(this));
@@ -522,6 +506,10 @@
             });
         }
 
+        if (!this.authenticated) {
+            callback('Must be authenticated to enable compression.');
+        }
+
         if (!this.options.enableCompression || this.capability.indexOf('COMPRESS=DEFLATE') < 0 || this.client.compressed) {
             setTimeout(function() {
                 callback(null, false);
@@ -564,10 +552,10 @@
      */
     BrowserBox.prototype.login = function(auth, callback) {
         var command, options = {};
-
         if (!auth) {
-            return callback(new Error('Authentication information not provided'));
+                return callback(new Error('Authentication information not provided'));
         }
+        this.options.auth = auth;
 
         if (this.capability.indexOf('AUTH=XOAUTH2') >= 0 && auth && auth.xoauth2) {
             command = {
@@ -628,6 +616,8 @@
                 this.capability = [].concat(response.capability || []);
                 capabilityUpdated = true;
                 axe.debug(DEBUG_TAG, this.options.sessionId + ' post-auth capabilites updated: ' + this.capability);
+                this.compressConnection();
+                this.onauth();
                 callback(null, true);
             } else if (response.payload && response.payload.CAPABILITY && response.payload.CAPABILITY.length) {
                 // capabilites were listed with * CAPABILITY ... response
@@ -636,6 +626,8 @@
                 });
                 capabilityUpdated = true;
                 axe.debug(DEBUG_TAG, this.options.sessionId + ' post-auth capabilites updated: ' + this.capability);
+                this.compressConnection();
+                this.onauth();
                 callback(null, true);
             } else {
                 // capabilities were not automatically listed, reload
@@ -648,7 +640,6 @@
                     }
                 }.bind(this));
             }
-
             next();
         }.bind(this));
     };

--- a/src/browserbox.js
+++ b/src/browserbox.js
@@ -204,7 +204,6 @@
     BrowserBox.prototype._onReady = function() {
         clearTimeout(this._connectionTimeout);
         axe.debug(DEBUG_TAG, this.options.sessionId + ' session: connection established');
-        this._changeState(this.STATE_NOT_AUTHENTICATED);
 
         this.updateCapability(function() {
             this.upgradeConnection(function(err) {
@@ -215,6 +214,11 @@
                     return;
                 }
                 this.updateId(this.options.id, function() {
+                    // We're nto done connecting until we've gotten our
+                    // capabilities updated, upgraded our connection,
+                    // an identified the server.
+                    this._changeState(this.STATE_NOT_AUTHENTICATED);
+
                     // ignore errors for exchanging ID values
                     this.login(this.options.auth, function(err) {
                         if (err) {


### PR DESCRIPTION
Currently browserbox tries to completely scaffold a connection on Browserbox.connect().  The onReady handler updates the capabilites, tries to upgrade the connection, identifies the server, tries to login, and enables compression. All off the error communication is done through the onerror event handler. 

While convenient it doesn't really reflect the semantics of the IMAP protocol which allows you to logout and in multiple times as different users within a single session. The out of bad error handling also makes it hard for consumers to respond to and recover from errors. 

This pull request introduces login() as a separate consumer drives step. It removes the automatic attempt to login on connect. If accepted upstream in browserbox, it should simplify down stream code in imap-client and mail-html5's connection doctor.  